### PR TITLE
send_sms worker

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "newrelic": "1.10.3",
     "pg.js": "2.11.1",
     "redis": "0.10.1",
-    "sqs-queue-parallel": "0.1.5",
+    "sqs-queue-parallel": "0.1.6",
     "webmaker-mailroom": "0.3.4"
   },
   "devDependencies": {

--- a/processor.js
+++ b/processor.js
@@ -32,6 +32,7 @@ var workers = async.applyEachSeries([
 //  worker.referrer_stats(redis_config),
   worker.remind_user_about_event(notifier_messager, mailroom),
   worker.login_request(notifier_messager, mailroom),
+  worker.send_sms(notifier_messager),
   worker.receive_coinbase_donation(notifier_messager, mailroom),
   worker.reset_request(notifier_messager, mailroom),
   worker.send_event_host_email(notifier_messager, mailroom),

--- a/worker/send_sms.js
+++ b/worker/send_sms.js
@@ -1,0 +1,17 @@
+module.exports = function(notifier_messager) {
+  var LUMBERYARD_EVENT = "send_sms";
+
+  return function(id, event, cb) {
+    if (event.event_type !== "send_sms") {
+      return process.nextTick(cb);
+    }
+
+    notifier_messager.sendMessage({
+      event_type: LUMBERYARD_EVENT,
+      data: {
+        to: event.data.to,
+        body: event.data.body
+      }
+    }, cb);
+  };
+};


### PR DESCRIPTION
mozilla/webmaker.org#1258

Adds a send_sms worker which accepts a `to` param (phone number) and a `body` param (sms message body) and sends a message to lumberyard